### PR TITLE
Gradle updated to create javadoc from kdocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,4 @@ README.html
 .idea
 .exercism
 .env
+*.hprof

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,24 +51,6 @@ plugins {
 }
 
 /**
- * generates dokkaGfmJar
- */
-tasks.register<Jar>("dokkaGfmJar") {
-    dependsOn(tasks.dokkaGfm)
-    from(tasks.dokkaGfm.flatMap { it.outputDirectory })
-    archiveClassifier.set("gfmdocs")
-}
-
-/**
- * generates dokkaHtmlJar
- */
-tasks.register<Jar>("dokkaHtmlJar") {
-    dependsOn(tasks.dokkaHtml)
-    from(tasks.dokkaHtml.flatMap { it.outputDirectory })
-    archiveClassifier.set("html-docs")
-}
-
-/**
  * creates javadocJar
  */
 tasks.register<Jar>("dokkaJavadocJar").configure {
@@ -77,16 +59,9 @@ tasks.register<Jar>("dokkaJavadocJar").configure {
     archiveClassifier.set("javadoc")
 }
 
-tasks.register<Jar>("dokkaJekyllJar").configure {
-    dependsOn(tasks.dokkaJekyll)
-    from(tasks.dokkaJekyll.flatMap { it.outputDirectory })
-    archiveClassifier.set("dokkajekyll")
-}
-
 /**
  * creates publishable kotlinSourcesJar, needed for automaticmanifest control
  */
-
 tasks.register<Jar>("kotlinSources").configure {
     dependsOn(tasks.kotlinSourcesJar)
     from(fileTree("src"))
@@ -136,16 +111,6 @@ dependencies {
 
 group = "app.pieces.pieces-os-client"
 version = "1.0.1"
-/**
-tasks.jar {
-    manifest.attributes["Main-Class"] = "$group"
-    val dependencies = configurations
-        .runtimeClasspath
-        .get()
-        .map(::zipTree) // OR .map { zipTree(it) }
-    from(dependencies)
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-}*/
 
 /**
  * adds automatic generation of manifest entries from files
@@ -193,15 +158,7 @@ publishing {
                     artifact(archives(tasks["dokkaJavadocJar"])) {
                         classifier = "javadoc"
                     }
-                    artifact(archives(tasks["dokkaHtmlJar"])) {
-                        classifier = "dokkahtml"
-                    }
-                    artifact(archives(tasks["dokkaGfmJar"])) {
-                        classifier = "gfmdocs"
-                    }
-                    artifact(archives(tasks["dokkaJekyllJar"])) {
-                        classifier = "dokkajekyll"
-                    }
+
                 }
             }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,7 +89,7 @@ publishing {
                     description.set("Pieces APIs for functional usage with Pieces OS on your local machine and build your own contextual copilot.")
                     url.set("https://pieces.app/")
                     artifactId = "pieces-os-client"
-                    groupId = "app.pieces.pieces-os-client"
+                    groupId = "app.pieces"
                     version = "1.0.0"
 
                 licenses {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -5,3 +5,5 @@ networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+#added the following line to have a large enough heap size to run dokkaJavadoc builds
+org.gradle.jvmargs=-XX:MaxMetaspaceSize=8128M

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -5,5 +5,7 @@ networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+org.gradle.jvmargs=-Xmx8192M -XX:MaxMetaspaceSize=8092M -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+
 #added the following line to have a large enough heap size to run dokkaJavadoc builds
-org.gradle.jvmargs=-XX:MaxMetaspaceSize=8128M
+

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,7 @@
+/**
+ * Needed to use plugins in build.gradle files
+ */
+
 pluginManagement {
     repositories {
         gradlePluginPortal()


### PR DESCRIPTION
Lot's of comments and some reference links(work in progress), has the functionality to generate 3 types of documentation.  The standard javadoc style is what's included in the javadoc jar.  As is, everything necessary should be command line accessible for running builds.